### PR TITLE
fix: clouddns plugin answers limited to one response

### DIFF
--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -168,9 +168,14 @@ func updateZoneFromRRS(rrs *gcp.ResourceRecordSetsListResponse, z *file.Zone) er
 			if err != nil {
 				return fmt.Errorf("failed to parse resource record: %v", err)
 			}
+
+			err = z.Insert(r)
+			if err != nil {
+				return fmt.Errorf("failed to insert record: %v", err)
+			}
+
 		}
 
-		z.Insert(r)
 	}
 	return nil
 }

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -114,6 +114,15 @@ func (c fakeGCPClient) listRRSets(ctx context.Context, projectName, hostedZoneNa
 				Type:    "SOA",
 				Rrdatas: []string{"ns-cloud-e1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
 			},
+			{
+				Name: "_dummy._tcp.example.org.",
+				Ttl:  300,
+				Type: "SRV",
+				Rrdatas: []string{
+					"0 0 5269 split-example.org",
+					"0 0 5269 other-example.org",
+				},
+			},
 		}
 	}
 
@@ -174,20 +183,20 @@ func TestCloudDNS(t *testing.T) {
 	}{
 		// 0. example.org A found - success.
 		{
-			qname: "example.org",
-			qtype: dns.TypeA,
+			qname:      "example.org",
+			qtype:      dns.TypeA,
 			wantAnswer: []string{"example.org.	300	IN	A	1.2.3.4"},
 		},
 		// 1. example.org AAAA found - success.
 		{
-			qname: "example.org",
-			qtype: dns.TypeAAAA,
+			qname:      "example.org",
+			qtype:      dns.TypeAAAA,
 			wantAnswer: []string{"example.org.	300	IN	AAAA	2001:db8:85a3::8a2e:370:7334"},
 		},
 		// 2. exampled.org PTR found - success.
 		{
-			qname: "example.org",
-			qtype: dns.TypePTR,
+			qname:      "example.org",
+			qtype:      dns.TypePTR,
 			wantAnswer: []string{"example.org.	300	IN	PTR	ptr.example.org."},
 		},
 		// 3. sample.example.org points to example.org CNAME.
@@ -203,14 +212,14 @@ func TestCloudDNS(t *testing.T) {
 		// 4. Explicit CNAME query for sample.example.org.
 		// Query must return just CNAME.
 		{
-			qname: "sample.example.org",
-			qtype: dns.TypeCNAME,
+			qname:      "sample.example.org",
+			qtype:      dns.TypeCNAME,
 			wantAnswer: []string{"sample.example.org.	300	IN	CNAME	example.org."},
 		},
 		// 5. Explicit SOA query for example.org.
 		{
-			qname: "example.org",
-			qtype: dns.TypeNS,
+			qname:  "example.org",
+			qtype:  dns.TypeNS,
 			wantNS: []string{"org.	300	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
 		},
 		// 6. AAAA query for split-example.org must return NODATA.
@@ -218,7 +227,7 @@ func TestCloudDNS(t *testing.T) {
 			qname:       "split-example.gov",
 			qtype:       dns.TypeAAAA,
 			wantRetCode: dns.RcodeSuccess,
-			wantNS: []string{"org.	300	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
+			wantNS:      []string{"org.	300	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
 		},
 		// 7. Zone not configured.
 		{
@@ -233,24 +242,24 @@ func TestCloudDNS(t *testing.T) {
 			qtype:        dns.TypeA,
 			wantRetCode:  dns.RcodeSuccess,
 			wantMsgRCode: dns.RcodeNameError,
-			wantNS: []string{"org.	300	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
+			wantNS:       []string{"org.	300	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
 		},
 		// 9. No record found. Fallthrough.
 		{
-			qname: "example.gov",
-			qtype: dns.TypeA,
+			qname:      "example.gov",
+			qtype:      dns.TypeA,
 			wantAnswer: []string{"example.gov.	300	IN	A	2.4.6.8"},
 		},
 		// 10. other-zone.example.org is stored in a different hosted zone. success
 		{
-			qname: "other-example.org",
-			qtype: dns.TypeA,
+			qname:      "other-example.org",
+			qtype:      dns.TypeA,
 			wantAnswer: []string{"other-example.org.	300	IN	A	3.5.7.9"},
 		},
 		// 11. split-example.org only has A record. Expect NODATA.
 		{
-			qname: "split-example.org",
-			qtype: dns.TypeAAAA,
+			qname:  "split-example.org",
+			qtype:  dns.TypeAAAA,
 			wantNS: []string{"org.	300	IN	SOA	ns-cloud-e1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 300 259200 300"},
 		},
 		// 12. *.www.example.org is a wildcard CNAME to www.example.org.
@@ -260,6 +269,15 @@ func TestCloudDNS(t *testing.T) {
 			wantAnswer: []string{
 				"a.www.example.org.	300	IN	CNAME	www.example.org.",
 				"www.example.org.	300	IN	A	1.2.3.4",
+			},
+		},
+		// 13. example.org SRV found with 2 answers - success.
+		{
+			qname: "_dummy._tcp.example.org.",
+			qtype: dns.TypeSRV,
+			wantAnswer: []string{
+				"_dummy._tcp.example.org.	300	IN	SRV	0 0 5269 split-example.org.",
+				"_dummy._tcp.example.org.	300	IN	SRV	0 0 5269 other-example.org.",
 			},
 		},
 	}


### PR DESCRIPTION
NOTE: this is an internal PR for review.  please do not merge. we'll be creating a PR to the coredns upstream later.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Inserts all the cloud record sets, not just the last one.

### 2. Which issues (if any) are related?

- fixes #5985

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

It's checking for insert errors. Not sure if this would be an issue.
